### PR TITLE
Code Quality Improvement - Exception handlers should preserve the original exception 

### DIFF
--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -10,6 +10,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -452,6 +453,7 @@ public class Socket extends Emitter {
             try {
                 v = array.get(i);
             } catch (JSONException e) {
+                logger.log(Level.WARNING, "An error occured while retrieving data from JSONArray", e);
                 v = null;
             }
             data[i] = v == JSONObject.NULL ? null : v;

--- a/src/main/java/io/socket/hasbinary/HasBinary.java
+++ b/src/main/java/io/socket/hasbinary/HasBinary.java
@@ -3,11 +3,15 @@ package io.socket.hasbinary;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import java.util.Iterator;
 
 public class HasBinary {
-
+	
+    private static final Logger logger = Logger.getLogger(HasBinary.class.getName());
+	
     private HasBinary() {}
 
     public static boolean hasBinary(Object data) {
@@ -29,6 +33,7 @@ public class HasBinary {
                 try {
                     v = _obj.isNull(i) ? null : _obj.get(i);
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while retrieving data from JSONArray", e);
                     return false;
                 }
                 if (_hasBinary(v)) {
@@ -44,7 +49,8 @@ public class HasBinary {
                 try {
                     v = _obj.get(key);
                 } catch (JSONException e) {
-                    return false;
+                    logger.log(Level.WARNING, "An error occured while retrieving data from JSONObject", e);
+                    return false;       
                 }
                 if (_hasBinary(v)) {
                     return true;

--- a/src/main/java/io/socket/parser/Binary.java
+++ b/src/main/java/io/socket/parser/Binary.java
@@ -7,13 +7,16 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Binary {
 
     private static final String KEY_PLACEHOLDER = "_placeholder";
 
     private static final String KEY_NUM = "num";
-
+    
+    private static final Logger logger = Logger.getLogger(Binary.class.getName());
 
     public static DeconstructedPacket deconstructPacket(Packet packet) {
         List<byte[]> buffers = new ArrayList<byte[]>();
@@ -36,6 +39,7 @@ public class Binary {
                 placeholder.put(KEY_PLACEHOLDER, true);
                 placeholder.put(KEY_NUM, buffers.size());
             } catch (JSONException e) {
+                logger.log(Level.WARNING, "An error occured while putting data to JSONObject", e);
                 return null;
             }
             buffers.add((byte[])data);
@@ -48,6 +52,7 @@ public class Binary {
                 try {
                     newData.put(i, _deconstructPacket(_data.get(i), buffers));
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while putting packet data to JSONObject", e);
                     return null;
                 }
             }
@@ -61,6 +66,7 @@ public class Binary {
                 try {
                     newData.put(key, _deconstructPacket(_data.get(key), buffers));
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while putting data to JSONObject", e);
                     return null;
                 }
             }
@@ -83,6 +89,7 @@ public class Binary {
                 try {
                     _data.put(i, _reconstructPacket(_data.get(i), buffers));
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while putting packet data to JSONObject", e);
                     return null;
                 }
             }
@@ -99,6 +106,7 @@ public class Binary {
                 try {
                     _data.put(key, _reconstructPacket(_data.get(key), buffers));
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while putting data to JSONObject", e);
                     return null;
                 }
             }

--- a/src/main/java/io/socket/parser/Parser.java
+++ b/src/main/java/io/socket/parser/Parser.java
@@ -7,6 +7,7 @@ import org.json.JSONTokener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class Parser {
@@ -227,6 +228,7 @@ public class Parser {
                     str.charAt(++i);
                     p.data = new JSONTokener(str.substring(i)).nextValue();
                 } catch (JSONException e) {
+                    logger.log(Level.WARNING, "An error occured while retrieving data from JSONTokener", e);
                     return error();
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - “Exception handlers should preserve the original exception”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1166

Please let me know if you have any questions.

Christian