### PR TITLE
Code Quality Improvement - Objects should be compared with "equals()"

### DIFF
--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -454,7 +454,7 @@ public class Socket extends Emitter {
             } catch (JSONException e) {
                 v = null;
             }
-            data[i] = v == JSONObject.NULL ? null : v;
+            data[i] = JSONObject.NULL.equals(v) ? null : v;
         }
         return data;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1698 - “Objects should be compared with "equals()"”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1698

Please let me know if you have any questions.

Christian