### PR TITLE
Code Quality Improvement - Constructors should only call non-overridable methods

### DIFF
--- a/src/main/java/io/socket/client/Manager.java
+++ b/src/main/java/io/socket/client/Manager.java
@@ -180,7 +180,7 @@ public class Manager extends Emitter {
         return this;
     }
 
-    public long reconnectionDelay() {
+    public final long reconnectionDelay() {
         return this._reconnectionDelay;
     }
 
@@ -192,7 +192,7 @@ public class Manager extends Emitter {
         return this;
     }
 
-    public double randomizationFactor() {
+    public final double randomizationFactor() {
         return this._randomizationFactor;
     }
 
@@ -204,7 +204,7 @@ public class Manager extends Emitter {
         return this;
     }
 
-    public long reconnectionDelayMax() {
+    public final long reconnectionDelayMax() {
         return this._reconnectionDelayMax;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Christian Ivan