### PR TITLE
Code Quality Improvement - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/java/io/socket/client/Manager.java
+++ b/src/main/java/io/socket/client/Manager.java
@@ -416,7 +416,7 @@ public class Manager extends Emitter {
 
     /*package*/ void destroy(Socket socket) {
         this.connected.remove(socket);
-        if (this.connected.size() > 0) return;
+        if (!this.connected.isEmpty()) return;
 
         this.close();
     }
@@ -447,7 +447,7 @@ public class Manager extends Emitter {
     }
 
     private void processPacketQueue() {
-        if (this.packetBuffer.size() > 0 && !this.encoding) {
+        if (!this.packetBuffer.isEmpty() && !this.encoding) {
             Packet pack = this.packetBuffer.remove(0);
             this.packet(pack);
         }

--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -312,7 +312,7 @@ public class Socket extends Emitter {
         }
 
         if (this.connected) {
-            if (args.size() == 0) return;
+            if (args.isEmpty()) return;
             String event = args.remove(0).toString();
             super.emit(event, args.toArray());
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.

Christian