### PR TITLE
Fixes event type when emitting binary_ack

### DIFF
--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -346,7 +346,13 @@ public class Socket extends Emitter {
                         sent[0] = true;
                         logger.fine(String.format("sending ack %s", args.length != 0 ? args : null));
 
-                        int type = HasBinary.hasBinary(args) ? Parser.BINARY_ACK : Parser.ACK;
+                        JSONArray jsonArgs = new JSONArray();
+                        for (Object arg : args) {
+                            jsonArgs.put(arg);
+                        }
+
+                        int type = HasBinary.hasBinary(jsonArgs)
+                            ? Parser.BINARY_ACK : Parser.ACK;
                         Packet<JSONArray> packet = new Packet<JSONArray>(type, new JSONArray(Arrays.asList(args)));
                         packet.id = id;
                         self.packet(packet);

--- a/src/test/resources/server.js
+++ b/src/test/resources/server.js
@@ -57,6 +57,17 @@ io.of(nsp).on('connection', function(socket) {
     });
   });
 
+  socket.on('callAckBinary', function() {
+    socket.emit('ack', function(buf) {
+      socket.emit('ackBack', buf);
+    });
+  });
+
+  socket.on('getAckBinary', function(data, callback) {
+    var buf = new Buffer('huehue', 'utf8');
+    callback(buf);
+  });
+
   socket.on('getAckDate', function(data, callback) {
     callback(new Date());
   });


### PR DESCRIPTION
> When submitting binary data in an Ack to the server the packet's type
> was not the expected (should be 6 - binary_ack - and not 3 - ack).

> This commit introduces tests as well a fix for the given problem.

Looks like this was fixed in https://github.com/socketio/socket.io-client-java/issues/62 but while running some tests we discovered that such code from the PR  was nos in the codebase anymore (discovered that after writing it). Sorry about not openning an issue first.

What do you think? Am i missing something?