### PR TITLE
Add condition to log only if fine level is loggable

### DIFF
--- a/src/main/java/io/socket/client/IO.java
+++ b/src/main/java/io/socket/client/IO.java
@@ -3,6 +3,7 @@ package io.socket.client;
 
 import io.socket.parser.Parser;
 
+import java.util.logging.Level;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import java.net.URI;
@@ -72,11 +73,15 @@ public class IO {
         Manager io;
 
         if (newConnection) {
-            logger.fine(String.format("ignoring socket cache for %s", source));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("ignoring socket cache for %s", source));
+            }
             io = new Manager(source, opts);
         } else {
             if (!managers.containsKey(id)) {
-                logger.fine(String.format("new io instance for %s", source));
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine(String.format("new io instance for %s", source));
+                }
                 managers.putIfAbsent(id, new Manager(source, opts));
             }
             io = managers.get(id);

--- a/src/main/java/io/socket/client/Manager.java
+++ b/src/main/java/io/socket/client/Manager.java
@@ -250,10 +250,14 @@ public class Manager extends Emitter {
         EventThread.exec(new Runnable() {
             @Override
             public void run() {
-                logger.fine(String.format("readyState %s", Manager.this.readyState));
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine(String.format("readyState %s", Manager.this.readyState));
+                }
                 if (Manager.this.readyState == ReadyState.OPEN || Manager.this.readyState == ReadyState.OPENING) return;
 
-                logger.fine(String.format("opening %s", Manager.this.uri));
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.fine(String.format("opening %s", Manager.this.uri));
+                }
                 Manager.this.engine = new Engine(Manager.this.uri, Manager.this.opts);
                 final io.socket.engineio.client.Socket socket = Manager.this.engine;
                 final Manager self = Manager.this;
@@ -453,7 +457,9 @@ public class Manager extends Emitter {
     }
 
     /*package*/ void packet(Packet packet) {
-        logger.fine(String.format("writing packet %s", packet));
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(String.format("writing packet %s", packet));
+        }
         final Manager self = this;
 
         if (!self.encoding) {

--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -273,7 +273,9 @@ public class Socket extends Emitter {
     }
 
     private void onclose(String reason) {
-        logger.fine(String.format("close (%s)", reason));
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(String.format("close (%s)", reason));
+        }
         this.connected = false;
         this.id = null;
         this.emit(EVENT_DISCONNECT, reason);
@@ -327,7 +329,9 @@ public class Socket extends Emitter {
 
     private void onevent(Packet<JSONArray> packet) {
         List<Object> args = new ArrayList<Object>(Arrays.asList(toArray(packet.data)));
-        logger.fine(String.format("emitting event %s", args));
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(String.format("emitting event %s", args));
+        }
 
         if (packet.id >= 0) {
             logger.fine("attaching ack callback to event");
@@ -354,7 +358,9 @@ public class Socket extends Emitter {
                     public void run() {
                         if (sent[0]) return;
                         sent[0] = true;
-                        logger.fine(String.format("sending ack %s", args.length != 0 ? args : null));
+                        if (logger.isLoggable(Level.FINE)) {
+                            logger.fine(String.format("sending ack %s", args.length != 0 ? args : null));
+                        }
 
                         JSONArray jsonArgs = new JSONArray();
                         for (Object arg : args) {
@@ -375,10 +381,14 @@ public class Socket extends Emitter {
     private void onack(Packet<JSONArray> packet) {
         Ack fn = this.acks.remove(packet.id);
         if (fn != null) {
-            logger.fine(String.format("calling ack %s with %s", packet.id, packet.data));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("calling ack %s with %s", packet.id, packet.data));
+            }
             fn.call(toArray(packet.data));
         } else {
-            logger.fine(String.format("bad ack %s", packet.id));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("bad ack %s", packet.id));
+            }
         }
     }
 
@@ -404,7 +414,9 @@ public class Socket extends Emitter {
     }
 
     private void ondisconnect() {
-        logger.fine(String.format("server disconnect (%s)", this.nsp));
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine(String.format("server disconnect (%s)", this.nsp));
+        }
         this.destroy();
         this.onclose("io server disconnect");
     }
@@ -431,7 +443,9 @@ public class Socket extends Emitter {
             @Override
             public void run() {
                 if (Socket.this.connected) {
-                    logger.fine(String.format("performing disconnect (%s)", Socket.this.nsp));
+                    if (logger.isLoggable(Level.FINE)) {
+                        logger.fine(String.format("performing disconnect (%s)", Socket.this.nsp));
+                    }
                     Socket.this.packet(new Packet(Parser.DISCONNECT));
                 }
 

--- a/src/main/java/io/socket/parser/Parser.java
+++ b/src/main/java/io/socket/parser/Parser.java
@@ -77,7 +77,9 @@ public class Parser {
         public Encoder() {}
 
         public void encode(Packet obj, Callback callback) {
-            logger.fine(String.format("encoding packet %s", obj));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("encoding packet %s", obj));
+            }
 
             if (BINARY_EVENT == obj.type || BINARY_ACK == obj.type) {
                 encodeAsBinary(obj, callback);
@@ -116,7 +118,9 @@ public class Parser {
                 str.append(obj.data);
             }
 
-            logger.fine(String.format("encoded %s as %s", obj, str));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("encoded %s as %s", obj, str));
+            }
             return str.toString();
         }
 
@@ -233,7 +237,9 @@ public class Parser {
                 }
             }
 
-            logger.fine(String.format("decoded %s as %s", str, p));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine(String.format("decoded %s as %s", str, p));
+            }
             return p;
         }
 


### PR DESCRIPTION
Even if FINE level is not loggable String.format() works every time and
tries to format string with all the events. Sometimes it causes
OutOfMemory exceptions.