### PR TITLE
update maven plugins versions and fix javadoc-plugin to work with jdk10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,6 @@
   <description>Socket.IO Client Library for Java</description>
   <url>https://github.com/socketio/socket.io-client-java</url>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
 
   <properties>
     <github.global.server>github</github.global.server>
@@ -105,7 +100,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.7.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
@@ -119,7 +114,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+          <version>2.21.0</version>
         <configuration>
           <argLine>-Dfile.encoding=UTF-8</argLine>
           <systemProperties>
@@ -160,7 +155,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.0.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -184,7 +186,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -195,7 +197,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>1.5.0</version>
+        <version>1.6.0</version>
         <executions>
           <execution>
             <id>npm-install</id>
@@ -216,7 +218,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
       </plugin>
       <plugin>
         <groupId>com.github.github</groupId>


### PR DESCRIPTION
## PROBLEM
If you try to build maven with jdk10 the javadoc generation will fail.
Issue reported here: 
https://issues.apache.org/jira/browse/MJAVADOC-517

## SOLUTION
Add commons-lang3 dependency to maven-javadoc-plugin

## TESTING
On JDK10 works, install, deploy and release

## NOTICE
I have also updated the other plugins and removed the parent tag as it has been deprecated see here for more info:
http://central.sonatype.org/pages/apache-maven.html#deprecated-oss-parent