### PR TITLE
Don't process socket.connect() if we are already re-connecting.

### DIFF
--- a/src/main/java/io/socket/client/Manager.java
+++ b/src/main/java/io/socket/client/Manager.java
@@ -191,6 +191,10 @@ public class Manager extends Emitter {
         return this;
     }
 
+    public boolean isReconnecting() {
+        return reconnecting;
+    }
+
     public int reconnectionAttempts() {
         return this._reconnectionAttempts;
     }

--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -136,7 +136,7 @@ public class Socket extends Emitter {
         EventThread.exec(new Runnable() {
             @Override
             public void run() {
-                if (Socket.this.connected) return;
+                if (Socket.this.connected || Socket.this.io.isReconnecting()) return;
 
                 Socket.this.subEvents();
                 Socket.this.io.open(); // ensure open


### PR DESCRIPTION
@nkzawa Fixes #576 .

I opted to not allow the socket.connect call to proceed if we're in re-connecting mode, because it is breaking re-connection in some edge cases.

The alternative would be to cancel reconnection, try to connect, and if failed, allow reconnection. While this option will make sure that a re-connection try happens whenever .connect() is called, and disregard the timer, it's more messy to code.
And I think that the first option is good enough, since the default max re-connection try is 5000ms