### PR TITLE
Add headers to sending pockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@
 .DS_Store
 target/
 node_modules/
+
+# VSCode project files
+*.prefs
+.project
+.classpath


### PR DESCRIPTION
Hello,

I noticed there is a need for adding custom headers in sending pockets, like JavaScript version. I added a method named addHeader which accepts a key and value as name and value of the header.
Use it as below:
`
Socket socket = IO.socket("http://localhost:3000", options);
socket.addHeader("authorization", token);`

Thanks to authors and contributors to create such a useful tool for java.  