### PR TITLE
docs: readme should state socket.io 2.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Socket.IO-client Java
 [![Build Status](https://travis-ci.org/socketio/socket.io-client-java.png?branch=master)](https://travis-ci.org/socketio/socket.io-client-java)
 
-This is the Socket.IO v1.x Client Library for Java, which is simply ported from the [JavaScript client](https://github.com/socketio/socket.io-client).
+This is the Socket.IO v1.x and v2.x Client Library for Java, which is simply ported from the [JavaScript client](https://github.com/socketio/socket.io-client).
 
 See also:
 
@@ -187,4 +187,3 @@ This library supports all of the features the JS client does, including events, 
 ## License
 
 MIT
-


### PR DESCRIPTION
README states that it only supports socket.io 1.x, but it does from v1.0.0.
https://github.com/socketio/socket.io-client-java/issues/421