### PR TITLE
Change `ParsedURI` visibility to public

### DIFF
--- a/src/main/java/io/socket/client/Url.java
+++ b/src/main/java/io/socket/client/Url.java
@@ -13,7 +13,7 @@ public class Url {
 
     private Url() {}
 
-    static class ParsedURI {
+    public static class ParsedURI {
         public final URI uri;
         public final String id;
 


### PR DESCRIPTION
The method `public static ParsedURI parse(URI uri)` is returning a `ParsedURI`which I can't use because it is not public (at least from Kotlin).