### PR TITLE
Adds `socket.open()` to initialization.md

### DIFF
--- a/src/site/markdown/initialization.md
+++ b/src/site/markdown/initialization.md
@@ -14,7 +14,7 @@ IO.Options options = IO.Options.builder()
 
 Socket socket = IO.socket(uri, options);
 
-// We can now connect to a server running socket.io
+// We can now connect to our server
 socket.open()
 ```
 

--- a/src/site/markdown/initialization.md
+++ b/src/site/markdown/initialization.md
@@ -15,7 +15,7 @@ IO.Options options = IO.Options.builder()
 Socket socket = IO.socket(uri, options);
 
 // We can now connect to our server
-socket.open()
+socket.open();
 ```
 
 Unlike the JS client (which can infer it from the `window.location` object), the URI is mandatory here.

--- a/src/site/markdown/initialization.md
+++ b/src/site/markdown/initialization.md
@@ -13,6 +13,9 @@ IO.Options options = IO.Options.builder()
         .build();
 
 Socket socket = IO.socket(uri, options);
+
+// We can now connect to a server running socket.io
+socket.open()
 ```
 
 Unlike the JS client (which can infer it from the `window.location` object), the URI is mandatory here.


### PR DESCRIPTION
Adds `socket.open()` line which is needed to connect to the server. 

Closes https://github.com/socketio/socket.io-client-java/issues/725 and prevents future similar issues.