### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           node-version: 14.x
       - name: Run the Maven verify phase
-        run: mvn verify -Dgpg.skip=true
+        run: mvn verify -Dgpg.skip=true -DdisableXmlReport=true


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.