### PR TITLE
Remove error-causing exclude

### DIFF
--- a/src/site/markdown/installation.md
+++ b/src/site/markdown/installation.md
@@ -26,10 +26,7 @@ Add the following dependency to your `pom.xml`.
 Add it as a gradle dependency for Android Studio, in `build.gradle`:
 
 ```groovy
-implementation ('io.socket:socket.io-client:2.1.0') {
-  // excluding org.json which is provided by Android
-  exclude group: 'org.json', module: 'json'
-}
+implementation ('io.socket:socket.io-client:2.1.0')
 ```
 
 ## Dependency tree


### PR DESCRIPTION
Previously, the exclude was required( https://github.com/socketio/engine.io-client-java/issues/13 ), but this was probably due to the fact that com.github.nkzawa:socket.io-client was used. Rather, now if you exclude it, you will get `java.lang.ClassNotFoundException: org.json.JSONException`.