### PR TITLE
• Using ConcurrentHashMap for multi-threaded environment

### DIFF
--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -9,6 +9,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -59,7 +60,7 @@ public class Socket extends Emitter {
     private String nsp;
     private Manager io;
     private Map<String, String> auth;
-    private Map<Integer, Ack> acks = new HashMap<>();
+    private Map<Integer, Ack> acks = new ConcurrentHashMap<>();
     private Queue<On.Handle> subs;
     private final Queue<List<Object>> receiveBuffer = new ConcurrentLinkedQueue<>();
     private final Queue<Packet<JSONArray>> sendBuffer = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
The current socket IO library suffers ConcurrentModificationException, leading to fatal crash on the Production environment.
I request to solve this issue, as it is affecting the end user.


![socket-io-clear_ack_bug](https://github.com/user-attachments/assets/b482bad9-cb9b-4eda-8082-7b42fc1db51d)
