### PR TITLE
feat: auth callback function

### DIFF
--- a/src/main/java/io/socket/client/Manager.java
+++ b/src/main/java/io/socket/client/Manager.java
@@ -553,6 +553,14 @@ public class Manager extends Emitter {
         }
     }
 
+    public interface AuthCallback {
+        void call(Map<String, String> auth);
+    }
+
+    public interface AuthFunction {
+        void call(AuthCallback callback);
+    }
+
     public static class Options extends io.socket.engineio.client.Socket.Options {
 
         public boolean reconnection = true;
@@ -562,6 +570,12 @@ public class Manager extends Emitter {
         public double randomizationFactor;
         public Parser.Encoder encoder;
         public Parser.Decoder decoder;
+        public AuthFunction authFunction = new AuthFunction() {
+            @Override
+            public void call(AuthCallback callback) {
+                callback.call(auth);
+            }
+        };
         public Map<String, String> auth;
 
         /**

--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -59,7 +59,7 @@ public class Socket extends Emitter {
     private int ids;
     private final String nsp;
     private final Manager io;
-    private final Map<String, String> auth;
+    private final Manager.AuthFunction authFunction;
     private final Map<Integer, Ack> acks = new ConcurrentHashMap<>();
     private Queue<On.Handle> subs;
     private final Queue<List<Object>> receiveBuffer = new ConcurrentLinkedQueue<>();
@@ -71,7 +71,7 @@ public class Socket extends Emitter {
     public Socket(Manager io, String nsp, Manager.Options opts) {
         this.io = io;
         this.nsp = nsp;
-        this.auth = opts != null ? opts.auth : null;
+        this.authFunction = opts != null ? opts.authFunction : null;
     }
 
     private void subEvents() {
@@ -268,8 +268,10 @@ public class Socket extends Emitter {
     private void onopen() {
         logger.fine("transport is open - connecting");
 
-        if (this.auth != null) {
-            this.packet(new Packet<>(Parser.CONNECT, new JSONObject(this.auth)));
+        if (this.authFunction != null) {
+            this.authFunction.call(auth ->
+                packet(new Packet<>(Parser.CONNECT, new JSONObject(auth)))
+            );
         } else {
             this.packet(new Packet<>(Parser.CONNECT));
         }

--- a/src/main/java/io/socket/client/SocketOptionBuilder.java
+++ b/src/main/java/io/socket/client/SocketOptionBuilder.java
@@ -78,7 +78,7 @@ public class SocketOptionBuilder {
                 .setSecure(options.secure)
                 .setPath(options.path)
                 .setQuery(options.query)
-                .setAuth(options.auth)
+                .setAuthFunction(options.authFunction)
                 .setExtraHeaders(options.extraHeaders);
         }
     }
@@ -175,7 +175,12 @@ public class SocketOptionBuilder {
     }
 
     public SocketOptionBuilder setAuth(Map<String, String> auth) {
-        this.options.auth = auth;
+        this.options.authFunction = callback -> callback.call(auth);
+        return this;
+    }
+
+    public SocketOptionBuilder setAuthFunction(Manager.AuthFunction authFunction) {
+        this.options.authFunction = authFunction;
         return this;
     }
 


### PR DESCRIPTION
JavaScript version of socket.io supports providing authentication as a callback function here: https://socket.io/docs/v4/client-options/#auth
This PR adds same exact functionality to the java version.