### PR TITLE
Client emit or send, nothing cames to server #790

### DIFF
--- a/src/main/java/io/socket/client/Socket.java
+++ b/src/main/java/io/socket/client/Socket.java
@@ -201,6 +201,21 @@ public class Socket extends Emitter {
         EventThread.exec(new Runnable() {
             @Override
             public void run() {
+                // warn if any argument is a JSON-looking string (common pitfall)
+                if (args != null) {
+                    for (Object arg : args) {
+                        if (arg instanceof CharSequence) {
+                            String s = arg.toString().trim();
+                            boolean looksLikeJsonObject = s.startsWith("{") && s.endsWith("}");
+                            boolean looksLikeJsonArray = s.startsWith("[") && s.endsWith("]");
+                            if (looksLikeJsonObject || looksLikeJsonArray) {
+                                logger.warning("Emitting a JSON-looking string. If you intend to send structured data, pass a JSONObject/JSONArray instead of a string.");
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 JSONArray jsonArgs = new JSONArray();
                 jsonArgs.put(event);
 

--- a/src/site/markdown/emitting_events.md
+++ b/src/site/markdown/emitting_events.md
@@ -71,6 +71,23 @@ object.put("test", "42");
 socket.emit("hello", 1, "2", bytes, object);
 ```
 
+### Common pitfall: stringified JSON
+
+If you intend to send structured data, do not pass a JSON-looking string like `"{me: 1449240991}"`. Send a `JSONObject` (or `JSONArray`) instead. Strings will be delivered as plain strings on the server.
+
+Client (wrong):
+
+```java
+socket.emit("authentication", "{me: 1449240991}"); // sent as a String, not an object
+```
+
+Client (correct):
+
+```java
+JSONObject payload = new JSONObject().put("me", 1449240991);
+socket.emit("authentication", payload);
+```
+
 ## Acknowledgements
 
 Events are great, but in some cases you may want a more classic request-response API. In Socket.IO, this feature is named acknowledgements.


### PR DESCRIPTION
I added a defensive improvement and documentation to address your issue.
- In Socket.emit(...), the client now logs a warning if you emit a JSON-looking string (e.g., "{...}" or "[...]"), prompting you to send a JSONObject/JSONArray instead.
- In src/site/markdown/emitting_events.md, I documented this pitfall with a “wrong vs correct” example.